### PR TITLE
add ID fields, deprecate Id fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ database for class, subclass, and programming interface information.
 
 Each `pcidb.PCIClass` struct contains the following fields:
 
-* `pcidb.PCIClass.Id` is the hex-encoded string identifier for the device
+* `pcidb.PCIClass.ID` is the hex-encoded string identifier for the device
   class
 * `pcidb.PCIClass.Name` is the common name/description of the class
 * `pcidb.PCIClass.Subclasses` is an array of pointers to
@@ -41,7 +41,7 @@ Each `pcidb.PCIClass` struct contains the following fields:
 
 Each `pcidb.PCISubclass` struct contains the following fields:
 
-* `pcidb.PCISubclass.Id` is the hex-encoded string identifier for the device
+* `pcidb.PCISubclass.ID` is the hex-encoded string identifier for the device
   subclass
 * `pcidb.PCISubclass.Name` is the common name/description of the subclass
 * `pcidb.PCISubclass.ProgrammingInterfaces` is an array of pointers to
@@ -50,7 +50,7 @@ Each `pcidb.PCISubclass` struct contains the following fields:
 
 Each `pcidb.PCIProgrammingInterface` struct contains the following fields:
 
-* `pcidb.PCIProgrammingInterface.Id` is the hex-encoded string identifier for
+* `pcidb.PCIProgrammingInterface.ID` is the hex-encoded string identifier for
   the programming interface
 * `pcidb.PCIProgrammingInterface.Name` is the common name/description for the
   programming interface
@@ -71,11 +71,11 @@ func main() {
 	}
 
 	for _, devClass := range pci.Classes {
-		fmt.Printf(" Device class: %v ('%v')\n", devClass.Name, devClass.Id)
+		fmt.Printf(" Device class: %v ('%v')\n", devClass.Name, devClass.ID)
         for _, devSubclass := range devClass.Subclasses {
-            fmt.Printf("    Device subclass: %v ('%v')\n", devSubclass.Name, devSubclass.Id)
+            fmt.Printf("    Device subclass: %v ('%v')\n", devSubclass.Name, devSubclass.ID)
             for _, progIface := range devSubclass.ProgrammingInterfaces {
-                fmt.Printf("        Programming interface: %v ('%v')\n", progIface.Name, progIface.Id)
+                fmt.Printf("        Programming interface: %v ('%v')\n", progIface.Name, progIface.ID)
             }
         }
 	}
@@ -115,16 +115,16 @@ database for vendor information and the products a vendor supplies.
 
 Each `pcidb.PCIVendor` struct contains the following fields:
 
-* `pcidb.PCIVendor.Id` is the hex-encoded string identifier for the vendor
+* `pcidb.PCIVendor.ID` is the hex-encoded string identifier for the vendor
 * `pcidb.PCIVendor.Name` is the common name/description of the vendor
 * `pcidb.PCIVendor.Products` is an array of pointers to `pcidb.PCIProduct`
   structs, one for each product supplied by the vendor
 
 Each `pcidb.PCIProduct` struct contains the following fields:
 
-* `pcidb.PCIProduct.VendorId` is the hex-encoded string identifier for the
+* `pcidb.PCIProduct.VendorID` is the hex-encoded string identifier for the
   product's vendor
-* `pcidb.PCIProduct.Id` is the hex-encoded string identifier for the product
+* `pcidb.PCIProduct.ID` is the hex-encoded string identifier for the product
 * `pcidb.PCIProduct.Name` is the common name/description of the subclass
 * `pcidb.PCIProduct.Subsystems` is an array of pointers to
   `pcidb.PCIProduct` structs, one for each "subsystem" (sometimes called
@@ -178,7 +178,7 @@ func main() {
 	fmt.Println("Top 5 vendors by product")
 	fmt.Println("====================================================")
 	for _, vendor := range vendors[0:5] {
-		fmt.Printf("%v ('%v') has %d products\n", vendor.Name, vendor.Id, len(vendor.Products))
+		fmt.Printf("%v ('%v') has %d products\n", vendor.Name, vendor.ID, len(vendor.Products))
 	}
 }
 ```
@@ -222,23 +222,23 @@ func (v ByCountSeparateSubvendors) Swap(i, j int) {
 }
 
 func (v ByCountSeparateSubvendors) Less(i, j int) bool {
-	iVendor := v[i].VendorId
+	iVendor := v[i].VendorID
 	iSetSubvendors := make(map[string]bool, 0)
 	iNumDiffSubvendors := 0
-	jVendor := v[j].VendorId
+	jVendor := v[j].VendorID
 	jSetSubvendors := make(map[string]bool, 0)
 	jNumDiffSubvendors := 0
 
 	for _, sub := range v[i].Subsystems {
-		if sub.VendorId != iVendor {
-			iSetSubvendors[sub.VendorId] = true
+		if sub.VendorID != iVendor {
+			iSetSubvendors[sub.VendorID] = true
 		}
 	}
 	iNumDiffSubvendors = len(iSetSubvendors)
 
 	for _, sub := range v[j].Subsystems {
-		if sub.VendorId != jVendor {
-			jSetSubvendors[sub.VendorId] = true
+		if sub.VendorID != jVendor {
+			jSetSubvendors[sub.VendorID] = true
 		}
 	}
 	jNumDiffSubvendors = len(jSetSubvendors)
@@ -264,24 +264,24 @@ func main() {
 	fmt.Println("Top 2 products by # different subvendors")
 	fmt.Println("====================================================")
 	for _, product := range products[0:2] {
-		vendorId := product.VendorId
-		vendor := pci.Vendors[vendorId]
+		vendorID := product.VendorID
+		vendor := pci.Vendors[vendorID]
 		setSubvendors := make(map[string]bool, 0)
 
 		for _, sub := range product.Subsystems {
-			if sub.VendorId != vendorId {
-				setSubvendors[sub.VendorId] = true
+			if sub.VendorID != vendorID {
+				setSubvendors[sub.VendorID] = true
 			}
 		}
-		fmt.Printf("%v ('%v') from %v\n", product.Name, product.Id, vendor.Name)
+		fmt.Printf("%v ('%v') from %v\n", product.Name, product.ID, vendor.Name)
 		fmt.Printf(" -> %d subsystems under the following different vendors:\n", len(setSubvendors))
-		for subvendorId, _ := range setSubvendors {
-			subvendor, exists := pci.Vendors[subvendorId]
+		for subvendorID, _ := range setSubvendors {
+			subvendor, exists := pci.Vendors[subvendorID]
 			subvendorName := "Unknown subvendor"
 			if exists {
 				subvendorName = subvendor.Name
 			}
-			fmt.Printf("      - %v ('%v')\n", subvendorName, subvendorId)
+			fmt.Printf("      - %v ('%v')\n", subvendorName, subvendorID)
 		}
 	}
 }

--- a/discover.go
+++ b/discover.go
@@ -42,7 +42,7 @@ func (db *PCIDB) load() error {
 	if foundPath == "" {
 		// OK, so we didn't find any host-local copy of the pci-ids DB file. Let's
 		// try fetching it from the network and storing it
-		if err := cachePCIIdsFile(cachePath); err != nil {
+		if err := cacheDBFile(cachePath); err != nil {
 			return err
 		}
 		foundPath = cachePath
@@ -53,7 +53,7 @@ func (db *PCIDB) load() error {
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
-	return parsePCIIdsFile(db, scanner)
+	return parseDBFile(db, scanner)
 }
 
 func cachePath() string {
@@ -108,7 +108,7 @@ func ensureDir(fp string) error {
 
 // Pulls down the latest copy of the pci-ids file from the network and stores
 // it in the local host filesystem
-func cachePCIIdsFile(cacheFilePath string) error {
+func cacheDBFile(cacheFilePath string) error {
 	ensureDir(cacheFilePath)
 
 	response, err := http.Get(PCIIDS_URI)

--- a/main.go
+++ b/main.go
@@ -7,18 +7,27 @@
 package pcidb
 
 type PCIProgrammingInterface struct {
-	Id   string // hex-encoded PCI_ID of the programming interface
+	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent ID field.
+	Id   string
+	ID   string // hex-encoded PCI_ID of the programming interface
 	Name string // common string name for the programming interface
 }
 
 type PCISubclass struct {
-	Id                    string                     // hex-encoded PCI_ID for the device subclass
+	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent ID field.
+	Id                    string
+	ID                    string                     // hex-encoded PCI_ID for the device subclass
 	Name                  string                     // common string name for the subclass
 	ProgrammingInterfaces []*PCIProgrammingInterface // any programming interfaces this subclass might have
 }
 
 type PCIClass struct {
-	Id         string         // hex-encoded PCI_ID for the device class
+	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent ID field.
+	Id         string
+	ID         string         // hex-encoded PCI_ID for the device class
 	Name       string         // common string name for the class
 	Subclasses []*PCISubclass // any subclasses belonging to this class
 }
@@ -26,14 +35,23 @@ type PCIClass struct {
 // NOTE(jaypipes): In the hardware world, the PCI "device_id" is the identifier
 // for the product/model
 type PCIProduct struct {
-	VendorId   string        // vendor ID for the product
-	Id         string        // hex-encoded PCI_ID for the product/model
+	// VendorId is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent VendorID field.
+	VendorId string
+	VendorID string // vendor ID for the product
+	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent ID field.
+	Id         string
+	ID         string        // hex-encoded PCI_ID for the product/model
 	Name       string        // common string name of the vendor
 	Subsystems []*PCIProduct // "subdevices" or "subsystems" for the product
 }
 
 type PCIVendor struct {
-	Id       string        // hex-encoded PCI_ID for the vendor
+	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
+	// use the equivalent ID field.
+	Id       string
+	ID       string        // hex-encoded PCI_ID for the vendor
 	Name     string        // common string name of the vendor
 	Products []*PCIProduct // all top-level devices for the vendor
 }

--- a/parse.go
+++ b/parse.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
+func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 	inClassBlock := false
 	db.Classes = make(map[string]*PCIClass, 20)
 	db.Vendors = make(map[string]*PCIVendor, 200)
@@ -45,14 +45,16 @@ func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
 				subclasses = make([]*PCISubclass, 0)
 			}
 			inClassBlock = true
-			classId := string(lineBytes[2:4])
+			classID := string(lineBytes[2:4])
 			className := string(lineBytes[6:])
 			curClass = &PCIClass{
-				Id:         classId,
+				// TODO)jaypipes): REMOVE in 1.0
+				Id:         classID,
+				ID:         classID,
 				Name:       className,
 				Subclasses: subclasses,
 			}
-			db.Classes[curClass.Id] = curClass
+			db.Classes[curClass.ID] = curClass
 			continue
 		}
 
@@ -68,14 +70,16 @@ func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
 				vendorProducts = make([]*PCIProduct, 0)
 			}
 			inClassBlock = false
-			vendorId := string(lineBytes[0:4])
+			vendorID := string(lineBytes[0:4])
 			vendorName := string(lineBytes[6:])
 			curVendor = &PCIVendor{
-				Id:       vendorId,
+				// TODO)jaypipes): REMOVE in 1.0
+				Id:       vendorID,
+				ID:       vendorID,
 				Name:     vendorName,
 				Products: vendorProducts,
 			}
-			db.Vendors[curVendor.Id] = curVendor
+			db.Vendors[curVendor.ID] = curVendor
 			continue
 		}
 
@@ -99,10 +103,10 @@ func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
 					curSubclass.ProgrammingInterfaces = progIfaces
 					progIfaces = make([]*PCIProgrammingInterface, 0)
 				}
-				subclassId := string(lineBytes[1:3])
+				subclassID := string(lineBytes[1:3])
 				subclassName := string(lineBytes[5:])
 				curSubclass = &PCISubclass{
-					Id:   subclassId,
+					ID:   subclassID,
 					Name: subclassName,
 					ProgrammingInterfaces: progIfaces,
 				}
@@ -113,13 +117,17 @@ func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
 					curProduct.Subsystems = productSubsystems
 					productSubsystems = make([]*PCIProduct, 0)
 				}
-				productId := string(lineBytes[1:5])
+				productID := string(lineBytes[1:5])
 				productName := string(lineBytes[7:])
-				productKey := curVendor.Id + productId
+				productKey := curVendor.ID + productID
 				curProduct = &PCIProduct{
-					VendorId: curVendor.Id,
-					Id:       productId,
-					Name:     productName,
+					// TODO)jaypipes): REMOVE in 1.0
+					VendorId: curVendor.ID,
+					VendorID: curVendor.ID,
+					// TODO)jaypipes): REMOVE in 1.0
+					Id:   productID,
+					ID:   productID,
+					Name: productName,
 				}
 				vendorProducts = append(vendorProducts, curProduct)
 				db.Products[productKey] = curProduct
@@ -139,21 +147,25 @@ func parsePCIIdsFile(db *PCIDB, scanner *bufio.Scanner) error {
 			//
 			// \t\t0e11 4091  Smart Array 6i
 			if inClassBlock {
-				progIfaceId := string(lineBytes[2:4])
+				progIfaceID := string(lineBytes[2:4])
 				progIfaceName := string(lineBytes[6:])
 				curProgIface = &PCIProgrammingInterface{
-					Id:   progIfaceId,
+					ID:   progIfaceID,
 					Name: progIfaceName,
 				}
 				progIfaces = append(progIfaces, curProgIface)
 			} else {
-				vendorId := string(lineBytes[2:6])
-				subsystemId := string(lineBytes[7:11])
+				vendorID := string(lineBytes[2:6])
+				subsystemID := string(lineBytes[7:11])
 				subsystemName := string(lineBytes[13:])
 				curSubsystem = &PCIProduct{
-					VendorId: vendorId,
-					Id:       subsystemId,
-					Name:     subsystemName,
+					// TODO)jaypipes): REMOVE in 1.0
+					VendorId: vendorID,
+					VendorID: vendorID,
+					// TODO)jaypipes): REMOVE in 1.0
+					Id:   subsystemID,
+					ID:   subsystemID,
+					Name: subsystemName,
 				}
 				productSubsystems = append(productSubsystems, curSubsystem)
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -40,7 +40,7 @@ func TestPCI(t *testing.T) {
 
 	var firewireSubclass *pcidb.PCISubclass
 	for _, sc := range sbController.Subclasses {
-		if sc.Id == "00" {
+		if sc.ID == "00" {
 			firewireSubclass = sc
 		}
 	}
@@ -54,7 +54,7 @@ func TestPCI(t *testing.T) {
 	}
 	var ohciIface *pcidb.PCIProgrammingInterface
 	for _, progIface := range firewireSubclass.ProgrammingInterfaces {
-		if progIface.Id == "10" {
+		if progIface.ID == "10" {
 			ohciIface = progIface
 		}
 	}
@@ -89,14 +89,14 @@ func TestPCI(t *testing.T) {
 	if intel10GBackplane.Name != "82599 10 Gigabit Dual Port Backplane Connection" {
 		t.Fatalf("Expected Intel product '10f8' to have name '82599 10 Gigabit Dual Port Backplane Connection' but got %v", intel10GBackplane.Name)
 	}
-	if intel10GBackplane.VendorId != "8086" {
-		t.Fatalf("Expected Intel product '10f8' to have vendor ID of '8086' but got '%v'", intel10GBackplane.VendorId)
+	if intel10GBackplane.VendorID != "8086" {
+		t.Fatalf("Expected Intel product '10f8' to have vendor ID of '8086' but got '%v'", intel10GBackplane.VendorID)
 	}
 
 	// Make sure this product is linked in the Intel PCIVendor.Products array
 	foundBackplane := false
 	for _, prod := range intelInc.Products {
-		if prod.Id == "10f8" {
+		if prod.ID == "10f8" {
 			foundBackplane = true
 		}
 	}
@@ -122,7 +122,7 @@ func TestPCI(t *testing.T) {
 	}
 	foundNetRaid := false
 	for _, subsystem := range megaRaidProd.Subsystems {
-		if subsystem.VendorId == "103c" && subsystem.Id == "60e7" {
+		if subsystem.VendorID == "103c" && subsystem.ID == "60e7" {
 			foundNetRaid = true
 		}
 	}


### PR DESCRIPTION
Adds new ID fields, deprecates old Id fields in structs.

Unfortunately, there's no hooks or anything that I can put in when an
attribute of a struct is used, so I can't output any WARNINGs or
anything to stderr when these now deprecated fields are used.

Issue #5