### PR TITLE
allow override chroot with New()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,16 @@
 
 
 [[projects]]
+  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "48ed4c2644ddada90ad75040098599bb025e049c7535a45df7fa8191292d4fe6"
+  input-imports = ["github.com/mitchellh/go-homedir"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -28,16 +28,26 @@ struct contains a number of fields that may be queried for PCI information:
 the term "product ID" in `pcidb` because it more accurately reflects what the
 identifier is for: a specific product line produced by the vendor.
 
-**NOTE**: The default root mountpoint that `pcidb` uses when looking for
-information about the host system is `/`. So, for example, when looking up
-known PCI IDS DB files on Linux, `pcidb` will attempt to discover a pciids DB
-file at `/usr/share/misc/pci.ids`. If you are calling `pcidb` from a system
-that has an alternate root mountpoint, you can set the `PCIDB_CHROOT`
-environment variable to that alternate path. for example, if you are executing
-from within an application container that has bind-mounted the root host
-filesystem to the mount point `/host`, you would set `PCIDB_CHROOT` to `/host`
-so that pcidb can find files like `/usr/share/misc/pci.ids` at
-`/host/usr/share/misc/pci.ids`.
+### Overriding the root mountpoint `pcidb` uses
+
+The default root mountpoint that `pcidb` uses when looking for information
+about the host system is `/`. So, for example, when looking up known PCI IDS DB
+files on Linux, `pcidb` will attempt to discover a pciids DB file at
+`/usr/share/misc/pci.ids`. If you are calling `pcidb` from a system that has an
+alternate root mountpoint, you can either set the `PCIDB_CHROOT` environment
+variable to that alternate path, or call the `pcidb.New()` function with the
+`pcidb.WithChroot()` modifier.
+
+For example, if you are executing from within an application container that has
+bind-mounted the root host filesystem to the mount point `/host`, you would set
+`PCIDB_CHROOT` to `/host` so that pcidb can find files like
+`/usr/share/misc/pci.ids` at `/host/usr/share/misc/pci.ids`.
+
+Alternately, you can use the `pcidb.WithChroot()` function like so:
+
+```go
+pci := pcidb.New(pcidb.WithChroot("/host"))
+```
 
 ### PCI device classes
 

--- a/internal_test.go
+++ b/internal_test.go
@@ -1,0 +1,30 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package pcidb
+
+import (
+	"testing"
+)
+
+func TestMergeOptions(t *testing.T) {
+	// Verify the default values are set if no overrides are passed
+	opts := mergeOptions()
+	if opts.Chroot == nil {
+		t.Fatalf("Expected opts.Chroot to be non-nil.")
+	}
+	if opts.CacheOnly == nil {
+		t.Fatalf("Expected opts.CacheOnly to be non-nil.")
+	}
+
+	// Verify if we pass an override, that value is used not the default
+	opts = mergeOptions(WithChroot("/override"))
+	if opts.Chroot == nil {
+		t.Fatalf("Expected opts.Chroot to be non-nil.")
+	} else if *opts.Chroot != "/override" {
+		t.Fatalf("Expected opts.Chroot to be /override.")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,16 @@
 
 package pcidb
 
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	cacheOnlyTrue = true
+)
+
 type PCIProgrammingInterface struct {
 	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
 	// use the equivalent ID field.
@@ -65,8 +75,84 @@ type PCIDB struct {
 	Products map[string]*PCIProduct
 }
 
-func New() (*PCIDB, error) {
+// WithOption is used to represent optionally-configured settings
+type WithOption struct {
+	// Chroot is the directory that pcidb uses when attempting to discover
+	// pciids DB files
+	Chroot *string
+	// CacheOnly is mostly just useful for testing. It essentially disables
+	// looking for any non ~/.cache/pci.ids filepaths (which is useful when we
+	// want to test the fetch-from-network code paths
+	CacheOnly *bool
+}
+
+func WithChroot(dir string) *WithOption {
+	return &WithOption{Chroot: &dir}
+}
+
+func WithCacheOnly() *WithOption {
+	return &WithOption{CacheOnly: &cacheOnlyTrue}
+}
+
+// Concrete merged set of configuration switches that get passed to pcidb
+// internal functions
+type options struct {
+	chroot    string
+	cacheOnly bool
+}
+
+func mergeOptions(opts ...*WithOption) *WithOption {
+	// Grab options from the environs by default
+	defaultChroot := "/"
+	if val, exists := os.LookupEnv("PCIDB_CHROOT"); exists {
+		defaultChroot = val
+	}
+	defaultCacheOnly := false
+	if val, exists := os.LookupEnv("PCIDB_CACHE_ONLY"); exists {
+		if parsed, err := strconv.ParseBool(val); err != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"Failed parsing a bool from PCIDB_CACHE_ONLY "+
+					"environ value of %s",
+				val,
+			)
+		} else if parsed {
+			defaultCacheOnly = parsed
+		}
+	}
+	mergeOpts := &WithOption{}
+	for _, opt := range opts {
+		if opt.Chroot != nil {
+			mergeOpts.Chroot = opt.Chroot
+		}
+		if opt.CacheOnly != nil {
+			mergeOpts.CacheOnly = opt.CacheOnly
+		}
+	}
+	// Set the default value if missing from mergeOpts
+	if mergeOpts.Chroot == nil {
+		mergeOpts.Chroot = &defaultChroot
+	}
+	if mergeOpts.CacheOnly == nil {
+		mergeOpts.CacheOnly = &defaultCacheOnly
+	}
+	return mergeOpts
+}
+
+// New returns a pointer to a PCIDB struct which contains information you can
+// use to query PCI vendor, product and class information. It accepts zero or
+// more pointers to WithOption structs. If you want to modify the behaviour of
+// pcidb, use one of the option modifiers when calling New. For example, to
+// change the root directory that pcidb uses when discovering pciids DB files,
+// call New(WithChroot("/my/root/override"))
+func New(opts ...*WithOption) (*PCIDB, error) {
+	mergeOpts := mergeOptions(opts...)
+	useOpts := &options{
+		chroot:    *mergeOpts.Chroot,
+		cacheOnly: *mergeOpts.CacheOnly,
+	}
+
 	db := &PCIDB{}
-	err := db.load()
+	err := db.load(useOpts)
 	return db, err
 }


### PR DESCRIPTION
Adds the ability to override the CHROOT and whether to only use the
cached pciids file using options passed to the `pcidb.New()` function.
The chroot still defaults to the PCIDB_CHROOT environs variable value,
if set, but now it's possible to set this configuration value like so:

```go
pci := pcidb.New(pcidb.WithChroot("/override"))
```

Issue #12