### PR TITLE
remove PCI prefix and Id fields

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,14 @@
 
 
 [[projects]]
-  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["github.com/mitchellh/go-homedir"]
+  inputs-digest = "48ed4c2644ddada90ad75040098599bb025e049c7535a45df7fa8191292d4fe6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The `pcidb.New()` function returns a `pcidb.PCIDB` struct. The `pcidb.PCIDB`
 struct contains a number of fields that may be queried for PCI information:
 
 * `pcidb.PCIDB.Classes` is a map, keyed by the PCI class ID (a hex-encoded
-  string) of pointers to `pcidb.PCIClass` structs, one for each class of PCI
+  string) of pointers to `pcidb.Class` structs, one for each class of PCI
   device known to `pcidb`
 * `pcidb.PCIDB.Vendors` is a map, keyed by the PCI vendor ID (a hex-encoded
-  string) of pointers to `pcidb.PCIVendor` structs, one for each PCI vendor
+  string) of pointers to `pcidb.Vendor` structs, one for each PCI vendor
   known to `pcidb`
 * `pcidb.PCIDB.Products` is a map, keyed by the PCI product ID* (a hex-encoded
-  string) of pointers to `pcidb.PCIProduct` structs, one for each PCI product
+  string) of pointers to `pcidb.Product` structs, one for each PCI product
   known to `pcidb`
 
 **NOTE**: PCI products are often referred to by their "device ID". We use
@@ -54,28 +54,28 @@ pci := pcidb.New(pcidb.WithChroot("/host"))
 Let's take a look at the PCI device class information and how to query the PCI
 database for class, subclass, and programming interface information.
 
-Each `pcidb.PCIClass` struct contains the following fields:
+Each `pcidb.Class` struct contains the following fields:
 
-* `pcidb.PCIClass.ID` is the hex-encoded string identifier for the device
+* `pcidb.Class.ID` is the hex-encoded string identifier for the device
   class
-* `pcidb.PCIClass.Name` is the common name/description of the class
-* `pcidb.PCIClass.Subclasses` is an array of pointers to
-  `pcidb.PCISubclass` structs, one for each subclass in the device class
+* `pcidb.Class.Name` is the common name/description of the class
+* `pcidb.Class.Subclasses` is an array of pointers to
+  `pcidb.Subclass` structs, one for each subclass in the device class
 
-Each `pcidb.PCISubclass` struct contains the following fields:
+Each `pcidb.Subclass` struct contains the following fields:
 
-* `pcidb.PCISubclass.ID` is the hex-encoded string identifier for the device
+* `pcidb.Subclass.ID` is the hex-encoded string identifier for the device
   subclass
-* `pcidb.PCISubclass.Name` is the common name/description of the subclass
-* `pcidb.PCISubclass.ProgrammingInterfaces` is an array of pointers to
-  `pcidb.PCIProgrammingInterface` structs, one for each programming interface
+* `pcidb.Subclass.Name` is the common name/description of the subclass
+* `pcidb.Subclass.ProgrammingInterfaces` is an array of pointers to
+  `pcidb.ProgrammingInterface` structs, one for each programming interface
    for the device subclass
 
-Each `pcidb.PCIProgrammingInterface` struct contains the following fields:
+Each `pcidb.ProgrammingInterface` struct contains the following fields:
 
-* `pcidb.PCIProgrammingInterface.ID` is the hex-encoded string identifier for
+* `pcidb.ProgrammingInterface.ID` is the hex-encoded string identifier for
   the programming interface
-* `pcidb.PCIProgrammingInterface.Name` is the common name/description for the
+* `pcidb.ProgrammingInterface.Name` is the common name/description for the
   programming interface
 
 ```go
@@ -136,21 +136,21 @@ Example output from my personal workstation, snipped for brevity:
 Let's take a look at the PCI vendor information and how to query the PCI
 database for vendor information and the products a vendor supplies.
 
-Each `pcidb.PCIVendor` struct contains the following fields:
+Each `pcidb.Vendor` struct contains the following fields:
 
-* `pcidb.PCIVendor.ID` is the hex-encoded string identifier for the vendor
-* `pcidb.PCIVendor.Name` is the common name/description of the vendor
-* `pcidb.PCIVendor.Products` is an array of pointers to `pcidb.PCIProduct`
+* `pcidb.Vendor.ID` is the hex-encoded string identifier for the vendor
+* `pcidb.Vendor.Name` is the common name/description of the vendor
+* `pcidb.Vendor.Products` is an array of pointers to `pcidb.Product`
   structs, one for each product supplied by the vendor
 
-Each `pcidb.PCIProduct` struct contains the following fields:
+Each `pcidb.Product` struct contains the following fields:
 
-* `pcidb.PCIProduct.VendorID` is the hex-encoded string identifier for the
+* `pcidb.Product.VendorID` is the hex-encoded string identifier for the
   product's vendor
-* `pcidb.PCIProduct.ID` is the hex-encoded string identifier for the product
-* `pcidb.PCIProduct.Name` is the common name/description of the subclass
-* `pcidb.PCIProduct.Subsystems` is an array of pointers to
-  `pcidb.PCIProduct` structs, one for each "subsystem" (sometimes called
+* `pcidb.Product.ID` is the hex-encoded string identifier for the product
+* `pcidb.Product.Name` is the common name/description of the subclass
+* `pcidb.Product.Subsystems` is an array of pointers to
+  `pcidb.Product` structs, one for each "subsystem" (sometimes called
   "sub-device" in PCI literature) for the product
 
 **NOTE**: A subsystem product may have a different vendor than its "parent" PCI
@@ -169,7 +169,7 @@ import (
 	"github.com/jaypipes/pcidb"
 )
 
-type ByCountProducts []*pcidb.PCIVendor
+type ByCountProducts []*pcidb.Vendor
 
 func (v ByCountProducts) Len() int {
 	return len(v)
@@ -189,7 +189,7 @@ func main() {
 		fmt.Printf("Error getting PCI info: %v", err)
 	}
 
-	vendors := make([]*pcidb.PCIVendor, len(pci.Vendors))
+	vendors := make([]*pcidb.Vendor, len(pci.Vendors))
 	x := 0
 	for _, vendor := range pci.Vendors {
 		vendors[x] = vendor
@@ -234,7 +234,7 @@ import (
 	"github.com/jaypipes/pcidb"
 )
 
-type ByCountSeparateSubvendors []*pcidb.PCIProduct
+type ByCountSeparateSubvendors []*pcidb.Product
 
 func (v ByCountSeparateSubvendors) Len() int {
 	return len(v)
@@ -275,7 +275,7 @@ func main() {
 		fmt.Printf("Error getting PCI info: %v", err)
 	}
 
-	products := make([]*pcidb.PCIProduct, len(pci.Products))
+	products := make([]*pcidb.Product, len(pci.Products))
 	x := 0
 	for _, product := range pci.Products {
 		products[x] = product

--- a/context.go
+++ b/context.go
@@ -1,0 +1,69 @@
+package pcidb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+// Concrete merged set of configuration switches that get passed to pcidb
+// internal functions
+type context struct {
+	chroot      string
+	cacheOnly   bool
+	cachePath   string
+	searchPaths []string
+}
+
+func contextFromOptions(merged *WithOption) *context {
+	ctx := &context{
+		chroot:      *merged.Chroot,
+		cacheOnly:   *merged.CacheOnly,
+		cachePath:   getCachePath(),
+		searchPaths: make([]string, 0),
+	}
+	ctx.setSearchPaths()
+	return ctx
+}
+
+func getCachePath() string {
+	hdir, err := homedir.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed getting homedir.Dir(): %v", err)
+		return ""
+	}
+	fp, err := homedir.Expand(filepath.Join(hdir, ".cache", "pci.ids"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed expanding local cache path: %v", err)
+		return ""
+	}
+	return fp
+}
+
+// Depending on the operating system, sets the context's searchPaths to a set
+// of local filepaths to search for a pci.ids database file
+func (ctx *context) setSearchPaths() {
+	// A set of filepaths we will first try to search for the pci-ids DB file
+	// on the local machine. If we fail to find one, we'll try pulling the
+	// latest pci-ids file from the network
+	ctx.searchPaths = append(ctx.searchPaths, ctx.cachePath)
+	if ctx.cacheOnly {
+		return
+	}
+
+	rootPath := ctx.chroot
+
+	if runtime.GOOS != "windows" {
+		ctx.searchPaths = append(
+			ctx.searchPaths,
+			filepath.Join(rootPath, "usr", "share", "hwdata", "pci.ids"),
+		)
+		ctx.searchPaths = append(
+			ctx.searchPaths,
+			filepath.Join(rootPath, "usr", "share", "misc", "pci.ids"),
+		)
+	}
+}

--- a/discover.go
+++ b/discover.go
@@ -9,42 +9,31 @@ package pcidb
 import (
 	"bufio"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 const (
 	PCIIDS_URI = "https://pci-ids.ucw.cz/v2.2/pci.ids.gz"
 )
 
-func (db *PCIDB) load(opts *options) error {
-	cachePath := cachePath()
-	// A set of filepaths we will first try to search for the pci-ids DB file
-	// on the local machine. If we fail to find one, we'll try pulling the
-	// latest pci-ids file from the network
-	paths := []string{cachePath}
-	addSearchPaths(opts, &paths)
+func (db *PCIDB) load(ctx *context) error {
 	var foundPath string
-	for _, fp := range paths {
+	for _, fp := range ctx.searchPaths {
 		if _, err := os.Stat(fp); err == nil {
 			foundPath = fp
 			break
 		}
 	}
-
 	if foundPath == "" {
 		// OK, so we didn't find any host-local copy of the pci-ids DB file. Let's
 		// try fetching it from the network and storing it
-		if err := cacheDBFile(cachePath); err != nil {
+		if err := cacheDBFile(ctx.cachePath); err != nil {
 			return err
 		}
-		foundPath = cachePath
+		foundPath = ctx.cachePath
 	}
 	f, err := os.Open(foundPath)
 	if err != nil {
@@ -53,35 +42,6 @@ func (db *PCIDB) load(opts *options) error {
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	return parseDBFile(db, scanner)
-}
-
-func cachePath() string {
-	hdir, err := homedir.Dir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed getting homedir.Dir(): %v", err)
-		return ""
-	}
-	fp, err := homedir.Expand(filepath.Join(hdir, ".cache", "pci.ids"))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed expanding local cache path: %v", err)
-		return ""
-	}
-	return fp
-}
-
-// Depending on the operating system, returns a set of local filepaths to
-// search for a pci.ids database file
-func addSearchPaths(opts *options, paths *[]string) {
-	if opts.cacheOnly {
-		return
-	}
-
-	rootPath := opts.chroot
-
-	if runtime.GOOS != "windows" {
-		*paths = append(*paths, filepath.Join(rootPath, "usr", "share", "hwdata", "pci.ids"))
-		*paths = append(*paths, filepath.Join(rootPath, "usr", "share", "misc", "pci.ids"))
-	}
 }
 
 func ensureDir(fp string) error {

--- a/main.go
+++ b/main.go
@@ -16,63 +16,51 @@ var (
 	cacheOnlyTrue = true
 )
 
-type PCIProgrammingInterface struct {
-	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent ID field.
-	Id   string
+// ProgrammingInterface is the PCI programming interface for a class of PCI
+// devices
+type ProgrammingInterface struct {
 	ID   string // hex-encoded PCI_ID of the programming interface
 	Name string // common string name for the programming interface
 }
 
-type PCISubclass struct {
-	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent ID field.
-	Id                    string
-	ID                    string                     // hex-encoded PCI_ID for the device subclass
-	Name                  string                     // common string name for the subclass
-	ProgrammingInterfaces []*PCIProgrammingInterface // any programming interfaces this subclass might have
+// Subclass is a subdivision of a PCI class
+type Subclass struct {
+	ID                    string                  // hex-encoded PCI_ID for the device subclass
+	Name                  string                  // common string name for the subclass
+	ProgrammingInterfaces []*ProgrammingInterface // any programming interfaces this subclass might have
 }
 
-type PCIClass struct {
-	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent ID field.
-	Id         string
-	ID         string         // hex-encoded PCI_ID for the device class
-	Name       string         // common string name for the class
-	Subclasses []*PCISubclass // any subclasses belonging to this class
+// Class is the PCI class
+type Class struct {
+	ID         string      // hex-encoded PCI_ID for the device class
+	Name       string      // common string name for the class
+	Subclasses []*Subclass // any subclasses belonging to this class
 }
 
+// Product provides information about a PCI device model
 // NOTE(jaypipes): In the hardware world, the PCI "device_id" is the identifier
 // for the product/model
-type PCIProduct struct {
-	// VendorId is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent VendorID field.
-	VendorId string
-	VendorID string // vendor ID for the product
-	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent ID field.
-	Id         string
-	ID         string        // hex-encoded PCI_ID for the product/model
-	Name       string        // common string name of the vendor
-	Subsystems []*PCIProduct // "subdevices" or "subsystems" for the product
+type Product struct {
+	VendorID   string     // vendor ID for the product
+	ID         string     // hex-encoded PCI_ID for the product/model
+	Name       string     // common string name of the vendor
+	Subsystems []*Product // "subdevices" or "subsystems" for the product
 }
 
-type PCIVendor struct {
-	// Id is DEPRECATED in 0.2 and will be removed in the 1.0 release. Please
-	// use the equivalent ID field.
-	Id       string
-	ID       string        // hex-encoded PCI_ID for the vendor
-	Name     string        // common string name of the vendor
-	Products []*PCIProduct // all top-level devices for the vendor
+// Vendor provides information about a device vendor
+type Vendor struct {
+	ID       string     // hex-encoded PCI_ID for the vendor
+	Name     string     // common string name of the vendor
+	Products []*Product // all top-level devices for the vendor
 }
 
 type PCIDB struct {
-	// hash of class ID -> class dbrmation
-	Classes map[string]*PCIClass
-	// hash of vendor ID -> vendor dbrmation
-	Vendors map[string]*PCIVendor
-	// hash of vendor ID + product/device ID -> product dbrmation
-	Products map[string]*PCIProduct
+	// hash of class ID -> class information
+	Classes map[string]*Class
+	// hash of vendor ID -> vendor information
+	Vendors map[string]*Vendor
+	// hash of vendor ID + product/device ID -> product information
+	Products map[string]*Product
 }
 
 // WithOption is used to represent optionally-configured settings

--- a/main.go
+++ b/main.go
@@ -82,13 +82,6 @@ func WithCacheOnly() *WithOption {
 	return &WithOption{CacheOnly: &cacheOnlyTrue}
 }
 
-// Concrete merged set of configuration switches that get passed to pcidb
-// internal functions
-type options struct {
-	chroot    string
-	cacheOnly bool
-}
-
 func mergeOptions(opts ...*WithOption) *WithOption {
 	// Grab options from the environs by default
 	defaultChroot := "/"
@@ -108,23 +101,23 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 			defaultCacheOnly = parsed
 		}
 	}
-	mergeOpts := &WithOption{}
+	merged := &WithOption{}
 	for _, opt := range opts {
 		if opt.Chroot != nil {
-			mergeOpts.Chroot = opt.Chroot
+			merged.Chroot = opt.Chroot
 		}
 		if opt.CacheOnly != nil {
-			mergeOpts.CacheOnly = opt.CacheOnly
+			merged.CacheOnly = opt.CacheOnly
 		}
 	}
-	// Set the default value if missing from mergeOpts
-	if mergeOpts.Chroot == nil {
-		mergeOpts.Chroot = &defaultChroot
+	// Set the default value if missing from merged
+	if merged.Chroot == nil {
+		merged.Chroot = &defaultChroot
 	}
-	if mergeOpts.CacheOnly == nil {
-		mergeOpts.CacheOnly = &defaultCacheOnly
+	if merged.CacheOnly == nil {
+		merged.CacheOnly = &defaultCacheOnly
 	}
-	return mergeOpts
+	return merged
 }
 
 // New returns a pointer to a PCIDB struct which contains information you can
@@ -134,13 +127,8 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 // change the root directory that pcidb uses when discovering pciids DB files,
 // call New(WithChroot("/my/root/override"))
 func New(opts ...*WithOption) (*PCIDB, error) {
-	mergeOpts := mergeOptions(opts...)
-	useOpts := &options{
-		chroot:    *mergeOpts.Chroot,
-		cacheOnly: *mergeOpts.CacheOnly,
-	}
-
+	ctx := contextFromOptions(mergeOptions(opts...))
 	db := &PCIDB{}
-	err := db.load(useOpts)
+	err := db.load(ctx)
 	return db, err
 }

--- a/parse.go
+++ b/parse.go
@@ -13,19 +13,19 @@ import (
 
 func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 	inClassBlock := false
-	db.Classes = make(map[string]*PCIClass, 20)
-	db.Vendors = make(map[string]*PCIVendor, 200)
-	db.Products = make(map[string]*PCIProduct, 1000)
-	subclasses := make([]*PCISubclass, 0)
-	progIfaces := make([]*PCIProgrammingInterface, 0)
-	var curClass *PCIClass
-	var curSubclass *PCISubclass
-	var curProgIface *PCIProgrammingInterface
-	vendorProducts := make([]*PCIProduct, 0)
-	var curVendor *PCIVendor
-	var curProduct *PCIProduct
-	var curSubsystem *PCIProduct
-	productSubsystems := make([]*PCIProduct, 0)
+	db.Classes = make(map[string]*Class, 20)
+	db.Vendors = make(map[string]*Vendor, 200)
+	db.Products = make(map[string]*Product, 1000)
+	subclasses := make([]*Subclass, 0)
+	progIfaces := make([]*ProgrammingInterface, 0)
+	var curClass *Class
+	var curSubclass *Subclass
+	var curProgIface *ProgrammingInterface
+	vendorProducts := make([]*Product, 0)
+	var curVendor *Vendor
+	var curProduct *Product
+	var curSubsystem *Product
+	productSubsystems := make([]*Product, 0)
 	for scanner.Scan() {
 		line := scanner.Text()
 		// skip comments and blank lines
@@ -42,14 +42,12 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 			if curClass != nil {
 				// finalize existing class because we found a new class block
 				curClass.Subclasses = subclasses
-				subclasses = make([]*PCISubclass, 0)
+				subclasses = make([]*Subclass, 0)
 			}
 			inClassBlock = true
 			classID := string(lineBytes[2:4])
 			className := string(lineBytes[6:])
-			curClass = &PCIClass{
-				// TODO)jaypipes): REMOVE in 1.0
-				Id:         classID,
+			curClass = &Class{
 				ID:         classID,
 				Name:       className,
 				Subclasses: subclasses,
@@ -67,14 +65,12 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 			if curVendor != nil {
 				// finalize existing vendor because we found a new vendor block
 				curVendor.Products = vendorProducts
-				vendorProducts = make([]*PCIProduct, 0)
+				vendorProducts = make([]*Product, 0)
 			}
 			inClassBlock = false
 			vendorID := string(lineBytes[0:4])
 			vendorName := string(lineBytes[6:])
-			curVendor = &PCIVendor{
-				// TODO)jaypipes): REMOVE in 1.0
-				Id:       vendorID,
+			curVendor = &Vendor{
 				ID:       vendorID,
 				Name:     vendorName,
 				Products: vendorProducts,
@@ -101,11 +97,11 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 				if curSubclass != nil {
 					// finalize existing subclass because we found a new subclass block
 					curSubclass.ProgrammingInterfaces = progIfaces
-					progIfaces = make([]*PCIProgrammingInterface, 0)
+					progIfaces = make([]*ProgrammingInterface, 0)
 				}
 				subclassID := string(lineBytes[1:3])
 				subclassName := string(lineBytes[5:])
-				curSubclass = &PCISubclass{
+				curSubclass = &Subclass{
 					ID:   subclassID,
 					Name: subclassName,
 					ProgrammingInterfaces: progIfaces,
@@ -115,19 +111,15 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 				if curProduct != nil {
 					// finalize existing product because we found a new product block
 					curProduct.Subsystems = productSubsystems
-					productSubsystems = make([]*PCIProduct, 0)
+					productSubsystems = make([]*Product, 0)
 				}
 				productID := string(lineBytes[1:5])
 				productName := string(lineBytes[7:])
 				productKey := curVendor.ID + productID
-				curProduct = &PCIProduct{
-					// TODO)jaypipes): REMOVE in 1.0
-					VendorId: curVendor.ID,
+				curProduct = &Product{
 					VendorID: curVendor.ID,
-					// TODO)jaypipes): REMOVE in 1.0
-					Id:   productID,
-					ID:   productID,
-					Name: productName,
+					ID:       productID,
+					Name:     productName,
 				}
 				vendorProducts = append(vendorProducts, curProduct)
 				db.Products[productKey] = curProduct
@@ -149,7 +141,7 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 			if inClassBlock {
 				progIfaceID := string(lineBytes[2:4])
 				progIfaceName := string(lineBytes[6:])
-				curProgIface = &PCIProgrammingInterface{
+				curProgIface = &ProgrammingInterface{
 					ID:   progIfaceID,
 					Name: progIfaceName,
 				}
@@ -158,14 +150,10 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 				vendorID := string(lineBytes[2:6])
 				subsystemID := string(lineBytes[7:11])
 				subsystemName := string(lineBytes[13:])
-				curSubsystem = &PCIProduct{
-					// TODO)jaypipes): REMOVE in 1.0
-					VendorId: vendorID,
+				curSubsystem = &Product{
 					VendorID: vendorID,
-					// TODO)jaypipes): REMOVE in 1.0
-					Id:   subsystemID,
-					ID:   subsystemID,
-					Name: subsystemName,
+					ID:       subsystemID,
+					Name:     subsystemName,
 				}
 				productSubsystems = append(productSubsystems, curSubsystem)
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,7 +38,7 @@ func TestPCI(t *testing.T) {
 		t.Fatalf("Expected >0 Subclasses for sbController, but found 0.")
 	}
 
-	var firewireSubclass *pcidb.PCISubclass
+	var firewireSubclass *pcidb.Subclass
 	for _, sc := range sbController.Subclasses {
 		if sc.ID == "00" {
 			firewireSubclass = sc
@@ -52,7 +52,7 @@ func TestPCI(t *testing.T) {
 	if len(firewireSubclass.ProgrammingInterfaces) == 0 {
 		t.Fatalf("Expected >0 Firewire programming interfaces, but found 0.")
 	}
-	var ohciIface *pcidb.PCIProgrammingInterface
+	var ohciIface *pcidb.ProgrammingInterface
 	for _, progIface := range firewireSubclass.ProgrammingInterfaces {
 		if progIface.ID == "10" {
 			ohciIface = progIface


### PR DESCRIPTION
THIS IS A BACKWARDS-INCOMPATIBLE CHANGE

Due to the fact that pcidb used to be a submodule in the ghw library,
all of its publicly-exposed structs used to be prefixed with "PCI". Now
that pcidb is its own library, there's no reason to continue using that
prefix.

Since this is a backwards-incompatible change, I took the opportunity to
remove the old "Id" fields which had been deprecated in the 0.2 release.
No use waiting around to remove those for a 1.0 release when this change
is backwards incompatible anyway.

Issue #9