### PR TITLE
Allow disabling network fetch of pci-ids DB file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,18 @@ We currently [test](https://travis-ci.org/jaypipes/pcidb/) `pcidb` on Linux, Win
 developers to query for information about hardware device classes, vendor and
 product information.
 
-The `pcidb.New()` function returns a `pcidb.PCIDB` struct. The `pcidb.PCIDB`
-struct contains a number of fields that may be queried for PCI information:
+The `pcidb.New()` function returns a `pcidb.PCIDB` struct or an error if the
+PCI database could not be loaded.
+
+> `pcidb`'s default behaviour is to first search for pci-ids DB files on the
+> local host system in well-known filesystem paths. If `pcidb` cannot find a
+> pci-ids DB file on the local host system, it will then fetch a current
+> pci-ids DB file from the network. You can disable this network-fetching
+> behaviour with the `pcidb.WithDisableNetworkFetch()` function or set the
+> `PCIDB_DISABLE_NETWORK_FETCH` to a non-0 value.
+
+The `pcidb.PCIDB` struct contains a number of fields that may be queried for
+PCI information:
 
 * `pcidb.PCIDB.Classes` is a map, keyed by the PCI class ID (a hex-encoded
   string) of pointers to `pcidb.Class` structs, one for each class of PCI

--- a/context.go
+++ b/context.go
@@ -12,18 +12,20 @@ import (
 // Concrete merged set of configuration switches that get passed to pcidb
 // internal functions
 type context struct {
-	chroot      string
-	cacheOnly   bool
-	cachePath   string
-	searchPaths []string
+	chroot              string
+	cacheOnly           bool
+	cachePath           string
+	disableNetworkFetch bool
+	searchPaths         []string
 }
 
 func contextFromOptions(merged *WithOption) *context {
 	ctx := &context{
-		chroot:      *merged.Chroot,
-		cacheOnly:   *merged.CacheOnly,
-		cachePath:   getCachePath(),
-		searchPaths: make([]string, 0),
+		chroot:              *merged.Chroot,
+		cacheOnly:           *merged.CacheOnly,
+		cachePath:           getCachePath(),
+		disableNetworkFetch: *merged.DisableNetworkFetch,
+		searchPaths:         make([]string, 0),
 	}
 	ctx.setSearchPaths()
 	return ctx

--- a/discover.go
+++ b/discover.go
@@ -28,6 +28,9 @@ func (db *PCIDB) load(ctx *context) error {
 		}
 	}
 	if foundPath == "" {
+		if ctx.disableNetworkFetch {
+			return ERR_NO_DB
+		}
 		// OK, so we didn't find any host-local copy of the pci-ids DB file. Let's
 		// try fetching it from the network and storing it
 		if err := cacheDBFile(ctx.cachePath); err != nil {

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,2 @@
+github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/internal_test.go
+++ b/internal_test.go
@@ -19,6 +19,9 @@ func TestMergeOptions(t *testing.T) {
 	if opts.CacheOnly == nil {
 		t.Fatalf("Expected opts.CacheOnly to be non-nil.")
 	}
+	if opts.DisableNetworkFetch == nil {
+		t.Fatalf("Expected opts.DisableNetworkFetch to be non-nil.")
+	}
 
 	// Verify if we pass an override, that value is used not the default
 	opts = mergeOptions(WithChroot("/override"))
@@ -26,5 +29,19 @@ func TestMergeOptions(t *testing.T) {
 		t.Fatalf("Expected opts.Chroot to be non-nil.")
 	} else if *opts.Chroot != "/override" {
 		t.Fatalf("Expected opts.Chroot to be /override.")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	// Start with a context with no search paths intentionally to test the
+	// disabling of the network fetch
+	ctx := &context{
+		disableNetworkFetch: true,
+		searchPaths:         []string{},
+	}
+	db := &PCIDB{}
+	err := db.load(ctx)
+	if err != ERR_NO_DB {
+		t.Fatalf("Expected ERR_NO_DB but got %s.", err)
 	}
 }


### PR DESCRIPTION
In secure environments or environments with no network connectivity, we
want to be able to disable the default behaviour of fetching a pci-ids
DB file from the network.

This patch adds a new `pcidb.WithDisableNetworkFetch()` function and
corresponding `PCIDB_DISABLE_NETWORK_FETCH` environs variable to do
exactly that.

Closes Issue #19