### PR TITLE
Add support for gzip-compressed database

### DIFF
--- a/context.go
+++ b/context.go
@@ -67,5 +67,13 @@ func (ctx *context) setSearchPaths() {
 			ctx.searchPaths,
 			filepath.Join(rootPath, "usr", "share", "misc", "pci.ids"),
 		)
+		ctx.searchPaths = append(
+			ctx.searchPaths,
+			filepath.Join(rootPath, "usr", "share", "hwdata", "pci.ids.gz"),
+		)
+		ctx.searchPaths = append(
+			ctx.searchPaths,
+			filepath.Join(rootPath, "usr", "share", "misc", "pci.ids.gz"),
+		)
 	}
 }

--- a/discover.go
+++ b/discover.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -43,7 +44,19 @@ func (db *PCIDB) load(ctx *context) error {
 		return err
 	}
 	defer f.Close()
-	scanner := bufio.NewScanner(f)
+
+	var scanner *bufio.Scanner
+	if strings.HasSuffix(foundPath, ".gz") {
+		var zipReader *gzip.Reader
+		if zipReader, err = gzip.NewReader(f); err != nil {
+			return err
+		}
+		defer zipReader.Close()
+		scanner = bufio.NewScanner(zipReader)
+	} else {
+		scanner = bufio.NewScanner(f)
+	}
+
 	return parseDBFile(db, scanner)
 }
 


### PR DESCRIPTION
For systems that store the database file in compressed form, directly
parse this instead of requiring an implementer to separately uncompress
to disk.

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>