### PR TITLE
Add option for direct path to pci.ids

### DIFF
--- a/context.go
+++ b/context.go
@@ -15,6 +15,7 @@ type context struct {
 	chroot              string
 	cacheOnly           bool
 	cachePath           string
+	path                string
 	disableNetworkFetch bool
 	searchPaths         []string
 }
@@ -25,6 +26,7 @@ func contextFromOptions(merged *WithOption) *context {
 		cacheOnly:           *merged.CacheOnly,
 		cachePath:           getCachePath(),
 		disableNetworkFetch: *merged.DisableNetworkFetch,
+		path:                *merged.Path,
 		searchPaths:         make([]string, 0),
 	}
 	ctx.setSearchPaths()
@@ -48,6 +50,11 @@ func getCachePath() string {
 // Depending on the operating system, sets the context's searchPaths to a set
 // of local filepaths to search for a pci.ids database file
 func (ctx *context) setSearchPaths() {
+	// Look in direct path first, if set
+	if ctx.path != "" {
+		ctx.searchPaths = append(ctx.searchPaths, ctx.path)
+		return
+	}
 	// A set of filepaths we will first try to search for the pci-ids DB file
 	// on the local machine. If we fail to find one, we'll try pulling the
 	// latest pci-ids file from the network

--- a/internal_test.go
+++ b/internal_test.go
@@ -22,6 +22,9 @@ func TestMergeOptions(t *testing.T) {
 	if opts.DisableNetworkFetch == nil {
 		t.Fatalf("Expected opts.DisableNetworkFetch to be non-nil.")
 	}
+	if opts.Path == nil {
+		t.Fatalf("Expected opts.DirectPath to be non-nil.")
+	}
 
 	// Verify if we pass an override, that value is used not the default
 	opts = mergeOptions(WithChroot("/override"))
@@ -29,6 +32,13 @@ func TestMergeOptions(t *testing.T) {
 		t.Fatalf("Expected opts.Chroot to be non-nil.")
 	} else if *opts.Chroot != "/override" {
 		t.Fatalf("Expected opts.Chroot to be /override.")
+	}
+
+	opts = mergeOptions(WithDirectPath("/mnt/direct/pci.ids"))
+	if opts.Path == nil {
+		t.Fatalf("Expected opts.DirectPath to be non-nil.")
+	} else if *opts.Path != "/mnt/direct/pci.ids" {
+		t.Fatalf("Expected opts.DirectPath to be /mnt/direct/pci.ids")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -93,6 +93,9 @@ type WithOption struct {
 	// Useful for secure environments or environments with no network
 	// connectivity.
 	DisableNetworkFetch *bool
+	// Path points to the absolute path of a pci.ids file in a non-standard
+	// location.
+	Path *string
 }
 
 func WithChroot(dir string) *WithOption {
@@ -101,6 +104,10 @@ func WithChroot(dir string) *WithOption {
 
 func WithCacheOnly() *WithOption {
 	return &WithOption{CacheOnly: &trueVar}
+}
+
+func WithDirectPath(path string) *WithOption {
+	return &WithOption{Path: &path}
 }
 
 func WithDisableNetworkFetch() *WithOption {
@@ -112,6 +119,10 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 	defaultChroot := "/"
 	if val, exists := os.LookupEnv("PCIDB_CHROOT"); exists {
 		defaultChroot = val
+	}
+	path := ""
+	if val, exists := os.LookupEnv("PCIDB_PATH"); exists {
+		path = val
 	}
 	defaultCacheOnly := false
 	if val, exists := os.LookupEnv("PCIDB_CACHE_ONLY"); exists {
@@ -151,6 +162,9 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 		if opt.DisableNetworkFetch != nil {
 			merged.DisableNetworkFetch = opt.DisableNetworkFetch
 		}
+		if opt.Path != nil {
+			merged.Path = opt.Path
+		}
 	}
 	// Set the default value if missing from merged
 	if merged.Chroot == nil {
@@ -161,6 +175,9 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 	}
 	if merged.DisableNetworkFetch == nil {
 		merged.DisableNetworkFetch = &defaultDisableNetworkFetch
+	}
+	if merged.Path == nil {
+		merged.Path = &path
 	}
 	return merged
 }


### PR DESCRIPTION
For systems placing the pci.ids database in a location other than
<chroot>/usr/share/misc/pci.ids

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>