### PR TITLE
Remove pci ids file if failure to fetch it

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -72,6 +72,11 @@ func cacheDBFile(cacheFilePath string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			os.Remove(cacheFilePath)
+		}
+	}()
 	defer f.Close()
 	// write the gunzipped contents to our local cache file
 	zr, err := gzip.NewReader(response.Body)


### PR DESCRIPTION
Previous to this patch, if retrieving pci ids file failed,
an empty and pointless pci ids file would be left on the host.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

Partially helps fix #25 