### PR TITLE
Fix fetching of PCI IDs file

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	PCIIDS_URI = "https://pci-ids.ucw.cz/v2.2/pci.ids.gz"
+	USER_AGENT = "golang-jaypipes-pcidb"
 )
 
 func (db *PCIDB) load(ctx *context) error {
@@ -63,7 +64,13 @@ func ensureDir(fp string) error {
 func cacheDBFile(cacheFilePath string) error {
 	ensureDir(cacheFilePath)
 
-	response, err := http.Get(PCIIDS_URI)
+	client := new(http.Client)
+	request, err := http.NewRequest("GET", PCIIDS_URI, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("User-Agent", USER_AGENT)
+	response, err := client.Do(request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Remote host requires user agent header to be set to get PCI IDs
file.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

Remote server denies pulling PCI ID file due to user agent not set and upon failure pcidb then leaves a blank file in ~/.cache so the next time this software is run, it does not retry fetching.

See comment for error output:
https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/306#issuecomment-756785623