### PR TITLE
Disable network fetch of PCI database by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ PCI database could not be loaded.
 
 > `pcidb`'s default behaviour is to first search for pci-ids DB files on the
 > local host system in well-known filesystem paths. If `pcidb` cannot find a
-> pci-ids DB file on the local host system, it will then fetch a current
-> pci-ids DB file from the network. You can disable this network-fetching
-> behaviour with the `pcidb.WithDisableNetworkFetch()` function or set the
-> `PCIDB_DISABLE_NETWORK_FETCH` to a non-0 value.
+> pci-ids DB file on the local host system, you can configure `pcidb` to fetch
+> a current pci-ids DB file from the network. You can enable this
+> network-fetching behaviour with the `pcidb.WithEnableNetworkFetch()` function
+> or set the `PCIDB_ENABLE_NETWORK_FETCH` to a non-0 value.
 
 The `pcidb.PCIDB` struct contains a number of fields that may be queried for
 PCI information:

--- a/context.go
+++ b/context.go
@@ -12,22 +12,22 @@ import (
 // Concrete merged set of configuration switches that get passed to pcidb
 // internal functions
 type context struct {
-	chroot              string
-	cacheOnly           bool
-	cachePath           string
-	path                string
-	disableNetworkFetch bool
-	searchPaths         []string
+	chroot             string
+	cacheOnly          bool
+	cachePath          string
+	path               string
+	enableNetworkFetch bool
+	searchPaths        []string
 }
 
 func contextFromOptions(merged *WithOption) *context {
 	ctx := &context{
-		chroot:              *merged.Chroot,
-		cacheOnly:           *merged.CacheOnly,
-		cachePath:           getCachePath(),
-		disableNetworkFetch: *merged.DisableNetworkFetch,
-		path:                *merged.Path,
-		searchPaths:         make([]string, 0),
+		chroot:             *merged.Chroot,
+		cacheOnly:          *merged.CacheOnly,
+		cachePath:          getCachePath(),
+		enableNetworkFetch: *merged.EnableNetworkFetch,
+		path:               *merged.Path,
+		searchPaths:        make([]string, 0),
 	}
 	ctx.setSearchPaths()
 	return ctx

--- a/discover.go
+++ b/discover.go
@@ -30,7 +30,7 @@ func (db *PCIDB) load(ctx *context) error {
 		}
 	}
 	if foundPath == "" {
-		if ctx.disableNetworkFetch {
+		if !ctx.enableNetworkFetch {
 			return ERR_NO_DB
 		}
 		// OK, so we didn't find any host-local copy of the pci-ids DB file. Let's

--- a/internal_test.go
+++ b/internal_test.go
@@ -19,8 +19,8 @@ func TestMergeOptions(t *testing.T) {
 	if opts.CacheOnly == nil {
 		t.Fatalf("Expected opts.CacheOnly to be non-nil.")
 	}
-	if opts.DisableNetworkFetch == nil {
-		t.Fatalf("Expected opts.DisableNetworkFetch to be non-nil.")
+	if opts.EnableNetworkFetch == nil {
+		t.Fatalf("Expected opts.EnableNetworkFetch to be non-nil.")
 	}
 	if opts.Path == nil {
 		t.Fatalf("Expected opts.DirectPath to be non-nil.")
@@ -46,8 +46,8 @@ func TestLoad(t *testing.T) {
 	// Start with a context with no search paths intentionally to test the
 	// disabling of the network fetch
 	ctx := &context{
-		disableNetworkFetch: true,
-		searchPaths:         []string{},
+		enableNetworkFetch: false,
+		searchPaths:        []string{},
 	}
 	db := &PCIDB{}
 	err := db.load(ctx)

--- a/main.go
+++ b/main.go
@@ -88,11 +88,9 @@ type WithOption struct {
 	// looking for any non ~/.cache/pci.ids filepaths (which is useful when we
 	// want to test the fetch-from-network code paths
 	CacheOnly *bool
-	// Disables the default behaviour of fetching a pci-ids from a known
-	// location on the network if no local pci-ids DB files can be found.
-	// Useful for secure environments or environments with no network
-	// connectivity.
-	DisableNetworkFetch *bool
+	// Enables fetching a pci-ids from a known location on the network if no
+	// local pci-ids DB files can be found.
+	EnableNetworkFetch *bool
 	// Path points to the absolute path of a pci.ids file in a non-standard
 	// location.
 	Path *string
@@ -110,8 +108,8 @@ func WithDirectPath(path string) *WithOption {
 	return &WithOption{Path: &path}
 }
 
-func WithDisableNetworkFetch() *WithOption {
-	return &WithOption{DisableNetworkFetch: &trueVar}
+func WithEnableNetworkFetch() *WithOption {
+	return &WithOption{EnableNetworkFetch: &trueVar}
 }
 
 func mergeOptions(opts ...*WithOption) *WithOption {
@@ -137,17 +135,17 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 			defaultCacheOnly = parsed
 		}
 	}
-	defaultDisableNetworkFetch := false
-	if val, exists := os.LookupEnv("PCIDB_DISABLE_NETWORK_FETCH"); exists {
+	defaultEnableNetworkFetch := false
+	if val, exists := os.LookupEnv("PCIDB_ENABLE_NETWORK_FETCH"); exists {
 		if parsed, err := strconv.ParseBool(val); err != nil {
 			fmt.Fprintf(
 				os.Stderr,
-				"Failed parsing a bool from PCIDB_DISABLE_NETWORK_FETCH "+
+				"Failed parsing a bool from PCIDB_ENABLE_NETWORK_FETCH "+
 					"environ value of %s",
 				val,
 			)
 		} else if parsed {
-			defaultDisableNetworkFetch = parsed
+			defaultEnableNetworkFetch = parsed
 		}
 	}
 
@@ -159,8 +157,8 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 		if opt.CacheOnly != nil {
 			merged.CacheOnly = opt.CacheOnly
 		}
-		if opt.DisableNetworkFetch != nil {
-			merged.DisableNetworkFetch = opt.DisableNetworkFetch
+		if opt.EnableNetworkFetch != nil {
+			merged.EnableNetworkFetch = opt.EnableNetworkFetch
 		}
 		if opt.Path != nil {
 			merged.Path = opt.Path
@@ -173,8 +171,8 @@ func mergeOptions(opts ...*WithOption) *WithOption {
 	if merged.CacheOnly == nil {
 		merged.CacheOnly = &defaultCacheOnly
 	}
-	if merged.DisableNetworkFetch == nil {
-		merged.DisableNetworkFetch = &defaultDisableNetworkFetch
+	if merged.EnableNetworkFetch == nil {
+		merged.EnableNetworkFetch = &defaultEnableNetworkFetch
 	}
 	if merged.Path == nil {
 		merged.Path = &path


### PR DESCRIPTION
Unfortunately, pcidb was abusing the hosting of the PCIIDS database (see
Issue #28). Looks like CI/CD jobs were executing in containers and the
container filesystem did not contain the linux host PCIIDS database,
causing pcidb to fetch the latest from the pci-ids.ucw.cz website.

This PR disables the network fetch behaviour of pcidb by default, which
should hopefully address the abusive calls to the pci-ids.ucw.cz hosting
service.

I'm working separately with @fromanih from Red Hat to identify any CI
jobs that might have triggered the fetch storm...

Signed-off-by: Jay Pipes <jaypipes@gmail.com>