### PR TITLE
Add VendorName to Product

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ type Class struct {
 type Product struct {
 	// vendor ID for the product
 	VendorID string `json:"vendor_id"`
+	// vendor name for the product
+	VendorName string `json:"vendor_name"`
 	// hex-encoded PCI_ID for the product/model
 	ID string `json:"id"`
 	// common string name of the vendor

--- a/parse.go
+++ b/parse.go
@@ -117,9 +117,10 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 				productName := string(lineBytes[7:])
 				productKey := curVendor.ID + productID
 				curProduct = &Product{
-					VendorID: curVendor.ID,
-					ID:       productID,
-					Name:     productName,
+					VendorID:   curVendor.ID,
+					VendorName: curVendor.Name,
+					ID:         productID,
+					Name:       productName,
 				}
 				vendorProducts = append(vendorProducts, curProduct)
 				db.Products[productKey] = curProduct
@@ -147,13 +148,21 @@ func parseDBFile(db *PCIDB, scanner *bufio.Scanner) error {
 				}
 				progIfaces = append(progIfaces, curProgIface)
 			} else {
+				var vendorName string
+				if curVendor != nil {
+					vendorName = curVendor.Name
+				} else {
+					vendorName = "unknown"
+				}
+				
 				vendorID := string(lineBytes[2:6])
 				subsystemID := string(lineBytes[7:11])
 				subsystemName := string(lineBytes[13:])
 				curSubsystem = &Product{
-					VendorID: vendorID,
-					ID:       subsystemID,
-					Name:     subsystemName,
+					VendorID:   vendorID,
+					VendorName: vendorName,
+					ID:         subsystemID,
+					Name:       subsystemName,
 				}
 				productSubsystems = append(productSubsystems, curSubsystem)
 			}


### PR DESCRIPTION
I have a heavily modified forked version of pcidb that uses embed for pci.ids; cant really send that as a PR as it'll break this which I do not want to do. Instead I've back ported what I feel is a useful addition of `VendorName` to `Product`. I haven't been able to test this on this exact release but it does work on my modified fork.