### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,9 +34,9 @@ jobs:
        with:
          go-version: 1.21
      - name: lint
-       uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+       uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
        with:
-         version: v1.53
+         version: v1.61.0
          args: --timeout=5m0s --verbose
          only-new-issues: true
 


### PR DESCRIPTION
Updates our linter to a more modern Github Action and underlying golanglint-ci binary.