### PR TITLE
remove mitchellh/go-homedir dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/jaypipes/pcidb)](https://goreportcard.com/report/github.com/jaypipes/pcidb)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
-`pcidb` is a small Golang library for programmatic querying of PCI vendor,
-product and class information.
+`pcidb` is a small Go library for programmatic querying of PCI vendor, product
+and class information.
 
-We currently test `pcidb` on Linux, Windows and MacOSX.
+We test `pcidb` on Linux, Windows and MacOSX.
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/jaypipes/pcidb
 
 go 1.21
-
-require github.com/mitchellh/go-homedir v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
-github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/types/default.go
+++ b/types/default.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -25,15 +23,10 @@ var (
 )
 
 func getCachePath() string {
-	hdir, err := homedir.Dir()
+	hdir, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed getting homedir.Dir(): %v", err)
+		fmt.Fprintf(os.Stderr, "Failed getting os.UserHomeDir(): %v", err)
 		return ""
 	}
-	fp, err := homedir.Expand(filepath.Join(hdir, ".cache", "pci.ids"))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed expanding local cache path: %v", err)
-		return ""
-	}
-	return fp
+	return filepath.Join(hdir, ".cache", "pci.ids")
 }


### PR DESCRIPTION
Removes the dependency on github.com/mitchellh/go-homedir, as that repository is now archived and Go standard library is all that is necessary.

Closes #36 