### PR TITLE
do not error when $HOME not set

### DIFF
--- a/internal/discover.go
+++ b/internal/discover.go
@@ -47,6 +47,9 @@ func Discover(opts *types.WithOption) (io.ReadCloser, error) {
 		if opts.CachePath != nil && *opts.CachePath != "" {
 			cachePath = *opts.CachePath
 		}
+		if cachePath == "" {
+			return nil, types.ErrNoPaths
+		}
 		// OK, so we didn't find any host-local copy of the pci-ids DB file. Let's
 		// try fetching it from the network and storing it
 		if err := cacheDBFile(cachePath); err != nil {

--- a/types/default.go
+++ b/types/default.go
@@ -7,7 +7,6 @@
 package types
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -25,7 +24,11 @@ var (
 func getCachePath() string {
 	hdir, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed getting os.UserHomeDir(): %v", err)
+		// os.UserHomeDir() returns an error when $HOME isn't set on Linux.
+		// This is the only error os.UserHomeDir() returns, and we don't care
+		// about it, so just ignore the error.
+		//
+		// https://github.com/jaypipes/pcidb/issues/38
 		return ""
 	}
 	return filepath.Join(hdir, ".cache", "pci.ids")

--- a/types/error.go
+++ b/types/error.go
@@ -9,7 +9,12 @@ package types
 import "errors"
 
 var (
-	ErrNoDB = errors.New("No pci-ids DB files found (and network fetch disabled)")
-	// Backwards-compat, deprecated, pleas reference ErrNoDB
+	ErrNoDB = errors.New(
+		"pcidb: No pci-ids DB files found (and network fetch disabled)",
+	)
+	ErrNoPaths = errors.New(
+		"pcidb: no search paths and cache path is empty.",
+	)
+	// Backwards-compat, deprecated, please reference ErrNoDB
 	ERR_NO_DB = ErrNoDB
 )


### PR DESCRIPTION
In calculating the default cache path, we were using the `os.UserHomeDir()` function to get the user's home directory. This function differs from the behaviour of mitchellh/go-homedir in that it errors out on Linux if `$HOME` is not set.

This caused issues in certain environments and so this PR simply returns an empty string when `$HOME` is unset and now returns an error only during pci.ids DB file discovery if search paths yields an empty slice AND cache path is empty AND network fetch is enabled.

Issue #38