### PR TITLE
Correct db paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ the local host.
 local host system in well-known filesystem paths (Linux and MacOS):
 
 * `/usr/share/hwdata/pci.ids`
-* `/usr/share/misc/pci.ids.gz`
-* `/usr/share/hwdata/pci.ids`
+* `/usr/share/misc/pci.ids`
+* `/usr/share/hwdata/pci.ids.gz`
 * `/usr/share/misc/pci.ids.gz`
 
 > **NOTE**: Windows does not have a `pci.ids` database file installed by


### PR DESCRIPTION
The values and order looked wrong so I checked against the code to correct.